### PR TITLE
Fixed duplicate mailto: link

### DIFF
--- a/caddy/caddy/template.html
+++ b/caddy/caddy/template.html
@@ -354,7 +354,7 @@ footer {
 		</main>
 		<footer>
 			<p>Served with <a rel="noopener noreferrer" href="https://caddyserver.com">Caddy</a> </p>
-			<p>To report an issue, kindly send an <a href="mailto:contact@jingk.ai">email</a>, or open a <a href="mailto:contact@jingk.ai">Github issue</a> (preferred)</p>
+			<p>To report an issue, kindly send an <a href="mailto:contact@jingk.ai">email</a>, or open a <a href="https://github.com/xlanor/mirror.jingk.ai">Github issue</a> (preferred)</p>
 			<p>This mirror is maintained by Jingkai Tan</p>
 		</footer>
 		<script>


### PR DESCRIPTION
Not sure if that was intended, but I saw the "GitHub Issue" link wasn't taking to the actual repository.